### PR TITLE
Add reusable workflows for GitHub Project automation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,96 @@
+# GitHub Actions ワークフロー
+
+このディレクトリには、GitHub Projectの運用を自動化するためのReusable workflowが含まれています。各リポジトリからはCaller workflowを通じてこれらを呼び出します。
+
+## GitHub Actionsとは
+
+GitHub Actionsは、リポジトリ上で発生するイベント（IssueのClose、PRのマージなど）をトリガーにして、あらかじめ定義した処理を自動実行する仕組みです。ワークフローは `.github/workflows/` 内のYAMLファイルで定義されています。
+
+実行状況やログは、各リポジトリの Actions タブから確認できます。
+
+## Iteration自動付与 (`set-iteration-on-close.yml`)
+
+**目的**: IssueやPRがCloseされたとき、そのIssue/PRが紐付いているGitHub Projectに「現在のIteration」を自動で設定します。これにより、システム系などが「いつ何が完了したか」をProject上で把握できるようになります。
+
+**動作の流れ**:
+
+1. IssueまたはPRがCloseされる
+2. GitHub Actionsが自動で起動する
+3. そのIssue/PRが紐付いている全てのGitHub Projectを確認する
+4. Iterationフィールドを持つProjectに対して、現在の日付に対応するIterationを自動設定する
+5. Iterationフィールドがない、または現在のIterationが見つからないProjectはスキップされる
+
+### 他のリポジトリへの導入方法
+
+以下の内容で `.github/workflows/close-set-iteration.yml` を作成するだけで導入できます。
+
+```yaml
+name: Set Iteration on Close
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  set-iteration:
+    uses: ut-issl/.github/.github/workflows/set-iteration-on-close.yml@main
+    secrets:
+      ITERATION_AUTOMATION_APP_ID: ${{ secrets.ITERATION_AUTOMATION_APP_ID }}
+      ITERATION_AUTOMATION_APP_PRIVATE_KEY: ${{ secrets.ITERATION_AUTOMATION_APP_PRIVATE_KEY }}
+```
+
+> [!NOTE]
+> この自動化は、Organization Secretsに登録されたGitHub App（`ITERATION_AUTOMATION_APP_ID`, `ITERATION_AUTOMATION_APP_PRIVATE_KEY`）の認証情報を利用しています。新たにリポジトリを追加する場合は、Organization Secretsの「Repository access」に対象リポジトリを追加する必要があります。
+
+## 系ラベル自動付与 (`auto-label-subsystem.yml`)
+
+**目的**: IssueやPRが作成されたとき、リポジトリに設定されている **Topic** をもとに、対応する系ラベル（`sys:CDH` など）を自動で付与します。
+
+**動作の流れ**:
+
+1. IssueまたはPRが作成される
+2. リポジトリのTopicを取得する
+3. Topic名からサフィックスを抽出し、マッピングテーブルに基づいて系ラベルを特定する
+4. 該当するラベルをIssue/PRに付与する
+
+**Topicと系ラベルのマッピング**:
+
+| Topicサフィックス | ラベル | 例 |
+|---|---|---|
+| `cdh` | `sys:CDH` | `geox-cdh` |
+| `thermal` | `sys:熱` | `geox-thermal` |
+| `structure` | `sys:構造` | `geox-structure` |
+| `comm` | `sys:通信` | `geox-comm` |
+| `aocs` | `sys:姿勢` | `geox-aocs` |
+| `power` | `sys:電源` | `geox-power` |
+| `orbit` | `sys:軌道` | `geox-orbit` |
+| `propulsion` | `sys:推進` | `geox-propulsion` |
+| `ground` | `sys:地上` | `geox-ground` |
+| `payload` | `sys:PL` | `geox-payload` |
+| `elec` | `sys:電装` | `geox-elec` |
+| `system` | `sys:システム` | `geox-system` |
+| `sw-team`（完全一致） | `sys:SW` | `sw-team` |
+| `se-team`（完全一致） | `sys:SE` | `se-team` |
+
+### 他のリポジトリへの導入方法
+
+以下の内容で `.github/workflows/auto-label-subsystem.yml` を作成するだけで導入できます。
+
+```yaml
+name: Auto Label Subsystem
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    uses: ut-issl/.github/.github/workflows/auto-label-subsystem.yml@main
+```
+
+> [!NOTE]
+> この自動化は `GITHUB_TOKEN` のみで動作し、追加のSecrets設定は不要です。リポジトリのTopicは GitHub の Settings > General > Topics から設定できます。Topic名は [issl-autoproject の rules.yaml](https://github.com/ut-issl/issl-autoproject/blob/main/rules.yaml) と同じ命名規則に従ってください。

--- a/.github/workflows/auto-label-subsystem.yml
+++ b/.github/workflows/auto-label-subsystem.yml
@@ -1,0 +1,83 @@
+name: Auto Label Subsystem (Reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply subsystem labels based on repository topics
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Mapping from topic suffix/name to sys label
+            const TOPIC_TO_LABEL = {
+              "cdh": "sys:CDH",
+              "thermal": "sys:熱",
+              "structure": "sys:構造",
+              "comm": "sys:通信",
+              "aocs": "sys:姿勢",
+              "power": "sys:電源",
+              "orbit": "sys:軌道",
+              "propulsion": "sys:推進",
+              "ground": "sys:地上",
+              "payload": "sys:PL",
+              "elec": "sys:電装",
+              "system": "sys:システム",
+              "sw-team": "sys:SW",
+              "se-team": "sys:SE",
+            };
+
+            // Get repository topics
+            const { data: repoData } = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const topics = repoData.topics || [];
+
+            if (topics.length === 0) {
+              core.info("No topics found on this repository. Skipping.");
+              return;
+            }
+
+            // Resolve labels from topics
+            const labelsToApply = new Set();
+            for (const topic of topics) {
+              // Check exact match first (e.g., "sw-team", "se-team")
+              if (TOPIC_TO_LABEL[topic]) {
+                labelsToApply.add(TOPIC_TO_LABEL[topic]);
+                continue;
+              }
+              // Check suffix match (e.g., "geox-cdh" → "cdh")
+              const suffix = topic.split("-").pop();
+              if (suffix && TOPIC_TO_LABEL[suffix]) {
+                labelsToApply.add(TOPIC_TO_LABEL[suffix]);
+              }
+            }
+
+            if (labelsToApply.size === 0) {
+              core.info(
+                `Topics [${topics.join(", ")}] did not match any subsystem. Skipping.`
+              );
+              return;
+            }
+
+            // Get the issue or PR number
+            const number =
+              context.payload.issue?.number ||
+              context.payload.pull_request?.number;
+            if (!number) {
+              core.warning("No issue or PR number found in event payload");
+              return;
+            }
+
+            const labels = [...labelsToApply];
+            core.info(`Applying labels: ${labels.join(", ")}`);
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              labels,
+            });

--- a/.github/workflows/set-iteration-on-close.yml
+++ b/.github/workflows/set-iteration-on-close.yml
@@ -1,0 +1,173 @@
+name: Set Iteration on Close (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      iteration-field-name:
+        description: "The name of the iteration field in the project"
+        required: false
+        type: string
+        default: "Iteration"
+    secrets:
+      ITERATION_AUTOMATION_APP_ID:
+        required: true
+      ITERATION_AUTOMATION_APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  set-iteration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ITERATION_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.ITERATION_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Set current iteration on all associated projects
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fieldName = "${{ inputs.iteration-field-name }}";
+
+            const nodeId =
+              context.payload.issue?.node_id ||
+              context.payload.pull_request?.node_id;
+            if (!nodeId) {
+              core.warning("No issue or PR found in event payload");
+              return;
+            }
+
+            // Get all project items with each project's iteration field in one query
+            const result = await github.graphql(
+              `
+                query ($nodeId: ID!, $fieldName: String!) {
+                  node(id: $nodeId) {
+                    ... on Issue {
+                      projectItems(first: 50) {
+                        nodes {
+                          id
+                          project {
+                            id
+                            title
+                            field(name: $fieldName) {
+                              ... on ProjectV2IterationField {
+                                id
+                                configuration {
+                                  iterations {
+                                    id
+                                    title
+                                    startDate
+                                    duration
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    ... on PullRequest {
+                      projectItems(first: 50) {
+                        nodes {
+                          id
+                          project {
+                            id
+                            title
+                            field(name: $fieldName) {
+                              ... on ProjectV2IterationField {
+                                id
+                                configuration {
+                                  iterations {
+                                    id
+                                    title
+                                    startDate
+                                    duration
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `,
+              { nodeId, fieldName }
+            );
+
+            const items = result.node?.projectItems?.nodes || [];
+            if (items.length === 0) {
+              core.info("Not associated with any project. Skipping.");
+              return;
+            }
+
+            const now = new Date();
+
+            for (const item of items) {
+              const project = item.project;
+              const iterationField = project.field;
+
+              // Skip projects without an iteration field
+              if (!iterationField?.configuration) {
+                core.info(
+                  `Project "${project.title}": No "${fieldName}" field. Skipping.`
+                );
+                continue;
+              }
+
+              // Find the current iteration
+              const currentIteration =
+                iterationField.configuration.iterations.find((iter) => {
+                  const start = new Date(iter.startDate);
+                  const end = new Date(start);
+                  end.setDate(end.getDate() + iter.duration);
+                  return now >= start && now < end;
+                });
+
+              if (!currentIteration) {
+                core.warning(
+                  `Project "${project.title}": No current iteration found. Skipping.`
+                );
+                continue;
+              }
+
+              // Set the iteration
+              await github.graphql(
+                `
+                  mutation (
+                    $projectId: ID!
+                    $itemId: ID!
+                    $fieldId: ID!
+                    $iterationId: String!
+                  ) {
+                    updateProjectV2ItemFieldValue(
+                      input: {
+                        projectId: $projectId
+                        itemId: $itemId
+                        fieldId: $fieldId
+                        value: { iterationId: $iterationId }
+                      }
+                    ) {
+                      projectV2Item {
+                        id
+                      }
+                    }
+                  }
+                `,
+                {
+                  projectId: project.id,
+                  itemId: item.id,
+                  fieldId: iterationField.id,
+                  iterationId: currentIteration.id,
+                }
+              );
+
+              core.info(
+                `Project "${project.title}": Set iteration to "${currentIteration.title}"`
+              );
+            }


### PR DESCRIPTION
## Summary
- Iteration自動付与（`set-iteration-on-close.yml`）と系ラベル自動付与（`auto-label-subsystem.yml`）のReusable workflowを`se-team-hub`から移動
- publicリポジトリに配置することで、private/publicを問わずOrganization内の全リポジトリから呼び出し可能にする
- ワークフローの説明を記載した`README.md`を追加

## Background
- se-team-hub（private）にReusable workflowを置いた場合、privateリポジトリからしか呼び出せない制約がある
- `.github`リポジトリはpublicであるため、この制約を回避できる
- 関連: ut-issl/se-team-hub#95

## Test plan
- [ ] このPRをマージ後、各リポジトリのcaller workflowの参照先を`ut-issl/.github`に更新
- [ ] se-team-hub, sw-integration-task-list, repository-templateのPRを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)